### PR TITLE
Fixed buffer offset at start of sweep capture 

### DIFF
--- a/IRBaboonCombined/Debug/IRBdbg_macbookloop.filtergraph
+++ b/IRBaboonCombined/Debug/IRBdbg_macbookloop.filtergraph
@@ -16,7 +16,7 @@
       </OUTPUTS>
     </LAYOUT>
   </FILTER>
-  <FILTER uid="8" x="0.486" y="0.784375">
+  <FILTER uid="8" x="0.476" y="0.89375">
     <PLUGIN name="Audio Output" descriptiveName="" format="Internal" category="I/O devices"
             manufacturer="JUCE" version="1.0" file="" uid="724248cb" isInstrument="0"
             fileTime="0" infoUpdateTime="0" numInputs="4" numOutputs="0"
@@ -35,7 +35,7 @@
           uiopen_Normal="1">
     <PLUGIN name="IRBaboon" format="VST3" category="Fx" manufacturer="Flixor"
             version="1.0.0" file="/Users/flixor/Projects/IRBaboon/IRBaboonCombined/Builds/MacOSX/build/Debug/IRBaboon.vst3"
-            uid="acfc6b5c" isInstrument="0" fileTime="176d498f250" infoUpdateTime="176d4a057d8"
+            uid="acfc6b5c" isInstrument="0" fileTime="176d498f250" infoUpdateTime="176d8a21a98"
             numInputs="3" numOutputs="2" isShell="0"/>
     <STATE>191.VMjLgXK....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOVMEUy.Ea0cVZtMEcgQWY9vSRC8Vav8lak4Fc9XCLt3hKt3hKt3hKt3hYRUUSTEETIckVwTjQisVTTgkdEYjKAQjYPQSPWgUdMcjKAQjct3hdA4hKt3hKt3hKtnTUv.UQAslXuk0UXoWUFE0YQcEV77RRC8Vav8lak4Fc9vyKVMEUy.Ea0cVZtMEcgQWY9..</STATE>
     <LAYOUT>

--- a/IRBaboonCombined/Debug/irbaboon.filtergraph
+++ b/IRBaboonCombined/Debug/irbaboon.filtergraph
@@ -35,7 +35,7 @@
           uiopen_Normal="1">
     <PLUGIN name="IRBaboon" format="VST3" category="Fx" manufacturer="Flixor"
             version="1.0.0" file="/Users/flixor/Projects/IRBaboon/IRBaboonCombined/Builds/MacOSX/build/Debug/IRBaboon.vst3"
-            uid="acfc6b5c" isInstrument="0" fileTime="176d3d5d130" infoUpdateTime="176d3d67e2c"
+            uid="acfc6b5c" isInstrument="0" fileTime="176d3f3ec38" infoUpdateTime="176d3facd99"
             numInputs="3" numOutputs="2" isShell="0"/>
     <STATE>191.VMjLgXK....O+fWarAhckI2bo8la8HRLt.iHfTlai8FYo41Y8HRUTYTK3HxO9.BOVMEUy.Ea0cVZtMEcgQWY9vSRC8Vav8lak4Fc9XCLt3hKt3hKt3hKt3hYRUUSTEETIckVwTjQisVTTgkdEYjKAQjYPQSPWgUdMcjKAQjct3hdA4hKt3hKt3hKtnTUv.UQAslXuk0UXoWUFE0YQcEV77RRC8Vav8lak4Fc9vyKVMEUy.Ea0cVZtMEcgQWY9..</STATE>
     <LAYOUT>
@@ -50,6 +50,7 @@
   </FILTER>
   <CONNECTION srcFilter="7" srcChannel="0" dstFilter="9" dstChannel="0"/>
   <CONNECTION srcFilter="7" srcChannel="1" dstFilter="9" dstChannel="1"/>
+  <CONNECTION srcFilter="7" srcChannel="2" dstFilter="9" dstChannel="2"/>
   <CONNECTION srcFilter="9" srcChannel="0" dstFilter="8" dstChannel="0"/>
   <CONNECTION srcFilter="9" srcChannel="1" dstFilter="8" dstChannel="1"/>
 </FILTERGRAPH>

--- a/IRBaboonCombined/Source/CircularBufferArray.cpp
+++ b/IRBaboonCombined/Source/CircularBufferArray.cpp
@@ -38,12 +38,11 @@ void CircularBufferArray::changeArraySize(int amountOfBuffers){
 	
 	if(amountOfBuffers == arraySize) return;
 	
-	if(amountOfBuffers == 0){
+	else if(amountOfBuffers == 0){
 		bufferArray.clear();
 		readIndex = 0;
 		writeIndex = 0;
 		arraySize = 0;
-		return;
 	}
 	
 	else if(amountOfBuffers > arraySize){

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -134,8 +134,8 @@ AutoKalibraDemoAudioProcessorEditor::AutoKalibraDemoAudioProcessorEditor (AutoKa
 	sliderZoomFiltLabel.attachToComponent(&sliderZoomFilt, true);
 
 	addAndMakeVisible(&outputVolumeSlider);
-	outputVolumeSlider.setRange(-60, -20);
-	outputVolumeSlider.setValue(-30.0);
+	outputVolumeSlider.setRange(-60, 0);
+	outputVolumeSlider.setValue(-20.0);
 	outputVolumeSlider.onValueChange = [this] { processor.setOutputVolume(outputVolumeSlider.getValue()); };
 
 	addAndMakeVisible(outputVolumeSliderLabel);

--- a/IRBaboonCombined/Source/PluginEditor.h
+++ b/IRBaboonCombined/Source/PluginEditor.h
@@ -47,6 +47,7 @@ public:
 	void playFiltAudioClick (bool toggleState);
 	void loadTargetClicked();
 	void makeupSizeMenuChanged();
+	void presweepSilenceMenuChanged();
 
 	/* thumbnails */
 	void changeListenerCallback(ChangeBroadcaster* source) override;
@@ -110,6 +111,8 @@ private:
 	Label toggleButtonLabel;
 	ToggleButton nullifyPhaseButton { "Phase" };
 	ToggleButton nullifyAmplitudeButton { "EQ" };
+	ComboBox presweepSilenceMenu;
+	int presweepSilence = 16384;
 	ComboBox makeupSizeMenu;
 	int makeupSize = 2048;
 	TextButton swapButton { "Swap target <-> base" };

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -35,7 +35,7 @@ AutoKalibraDemoAudioProcessor::AutoKalibraDemoAudioProcessor()
 	
 	sweepBuf.setSize(1, totalSweepBreakSamples);
 	sweepBuf.clear();
-	sweepBuf.copyFrom(0, silenceBeginningLengthSamples, sweeper.getSweepFloat(), 0, 0, sweepLengthSamples);
+	sweepBuf.copyFrom(0, 0, sweeper.getSweepFloat(), 0, 0, sweepLengthSamples);
 	
 	sweepBufForDeconv.setSize(1, totalSweepBreakSamples);
 	sweepBufForDeconv.clear();
@@ -353,7 +353,7 @@ void AutoKalibraDemoAudioProcessor::processBlock (AudioBuffer<float>& buffer, Mi
 		}
 		
 		/* when done: play sweep now, start input capture next block */
-		if (buffersWaitForInputCapture == 0){
+		if (buffersWaitForInputCapture <= 0){
 			IRCapture.state = IRCAP_CAPTURE;
 			IRCapture.playSweep = true;
 		}

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -861,6 +861,11 @@ void AutoKalibraDemoAudioProcessor::setNullifyAmplFilt(bool nullifyAmplitude){
 }
 
 
+void AutoKalibraDemoAudioProcessor::setPresweepSilence(int presweepSilence){
+	samplesWaitBeforeInputCapture = presweepSilence;
+}
+
+
 void AutoKalibraDemoAudioProcessor::setMakeupSize(int makeupSize){
 	makeupIRLengthSamples = makeupSize;
 	

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -573,7 +573,8 @@ void AutoKalibraDemoAudioProcessor::processBlock (AudioBuffer<float>& buffer, Mi
 	
 	/* makeshift limiter lol */
 	if (tools::linTodB(buffer.getMagnitude(0, 0, generalHostBlockSize)) > 0.0){
-		tools::normalize(&buffer, 0.0, true);
+		tools::normalize(&buffer, 0.0, false);
+		DBG("processBlock limiter engaged\n");
 	}
 	
 }

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -114,6 +114,7 @@ public:
 	
 	void setNullifyPhaseFilt(bool nullifyPhase);
 	void setNullifyAmplFilt(bool nullifyAmplitude);
+	void setPresweepSilence(int presweepSilence);
 	void setMakeupSize(int makeupSize);
 	void swapTargetBase();
 	void loadTarget(File file);

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -146,13 +146,12 @@ private:
 	int sampleRate = 48000;
 	int generalHostBlockSize = 0;
 	
-	int silenceBeginningLengthSamples = 4096;
+
 	int silenceEndLengthSamples = 16384;
-	/* total samples = 4 * 32786 = 131072 */
-	int totalSweepBreakSamples = 4 * tools::nextPowerOfTwo(silenceBeginningLengthSamples + silenceEndLengthSamples + 1);
-	int sweepLengthSamples = totalSweepBreakSamples - silenceBeginningLengthSamples - silenceEndLengthSamples;
+	int totalSweepBreakSamples = 4 * silenceEndLengthSamples;
+	int sweepLengthSamples = totalSweepBreakSamples - silenceEndLengthSamples;
 	
-	int samplesWaitBeforeInputCapture = 16384; // 8 * 256
+	int samplesWaitBeforeInputCapture = 16384;
 	int buffersWaitForInputCapture = 0;
 	int buffersWaitForResumeThroughput = 0;
 	

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -152,7 +152,7 @@ private:
 	int totalSweepBreakSamples = 4 * tools::nextPowerOfTwo(silenceBeginningLengthSamples + silenceEndLengthSamples + 1);
 	int sweepLengthSamples = totalSweepBreakSamples - silenceBeginningLengthSamples - silenceEndLengthSamples;
 	
-	int samplesWaitBeforeInputCapture = 2048; // 8 * 256
+	int samplesWaitBeforeInputCapture = 16384; // 8 * 256
 	int buffersWaitForInputCapture = 0;
 	int buffersWaitForResumeThroughput = 0;
 	
@@ -160,7 +160,6 @@ private:
 	AudioSampleBuffer sweepBufForDeconv;
 	CircularBufferArray sweepBufArray;
 	CircularBufferArray inputCaptureArray;
-	AudioSampleBuffer inputConsolidated;
 
 	int makeupIRLengthSamples = 2048;
 	


### PR DESCRIPTION
This has been done by adding presweep silence. A button has also been added to manually adjust the presweep silence, in power of 2 amounts of samples (the user sees the length in seconds). The button becomes invisible when a sweep is triggered to avoid race conditions. 

Fixes #2 