### PR TITLE
Bugfix zoomvalue update

### DIFF
--- a/IRBaboonCombined/Builds/MacOSX/IRBaboon.xcodeproj/project.xcworkspace/xcuserdata/flixor.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/IRBaboonCombined/Builds/MacOSX/IRBaboon.xcodeproj/project.xcworkspace/xcuserdata/flixor.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/IRBaboonCombined/Builds/MacOSX/includes/CircularBufferArray.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/CircularBufferArray.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Builds/MacOSX/includes/CircularBufferArray.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/CircularBufferArray.hpp
@@ -3,8 +3,8 @@
 //
 
 
-#ifndef FP_CIRCULARBUFFERARRAY_HPP
-#define FP_CIRCULARBUFFERARRAY_HPP
+#pragma once
+
 
 #include <fp_include_all.hpp>
 #include <JuceHeader.h>
@@ -60,4 +60,3 @@ private:
 
 } // fp
 
-#endif /* FP_CIRCULARBUFFERARRAY_HPP */

--- a/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
@@ -34,7 +34,7 @@ namespace convolver {
 	/* Deconvolution is non-periodic, meaning it won't fold back, but output a buffer that is at least N_numerator + N_denominator + 1 samples.
 	 * The deconvolution uses complex division.
 	 * The denominator buffer needs to be mono! */
-	AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<float>* denominatorBuffer, double sampleRate, bool smoothing = true, bool nullifyPhase = false, bool nullifyAmplitude = false);
+	AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<float>* denominatorBuffer, double sampleRate, bool smoothing = true, bool includePhase = true, bool includeAmplitude = true);
 
 	/* the filter has a low-pass effect in the upper freqs if the fft method performForwardRealFreqOnly() has been used,
 	 * because the upper bin range will eventually go into negative freq bin territory, where the contents of the bins are 0,

--- a/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/Convolver.hpp
@@ -3,8 +3,8 @@
 //
 
 
-#ifndef FP_CONVOLVER_HPP
-#define FP_CONVOLVER_HPP
+#pragma once
+
 
 #include <fp_include_all.hpp>
 #include <JuceHeader.h>
@@ -76,5 +76,3 @@ namespace convolver {
 } // convolver
 	
 } // fp
-
-#endif /* FP_CONVOLVER_HPP */

--- a/IRBaboonCombined/Builds/MacOSX/includes/ExpSineSweep.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/ExpSineSweep.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Builds/MacOSX/includes/ExpSineSweep.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/ExpSineSweep.hpp
@@ -3,8 +3,8 @@
 //
 
 
-#ifndef FP_EXPSINESWEEP_HPP
-#define FP_EXPSINESWEEP_HPP
+#pragma once
+
 
 #include <fp_include_all.hpp>
 #include <JuceHeader.h>
@@ -59,6 +59,3 @@ private:
 };
 
 } // fp
-
-#endif /* FP_EXPSINESWEEP_HPP */
-

--- a/IRBaboonCombined/Builds/MacOSX/includes/ParallelBufferPrinter.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/ParallelBufferPrinter.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Builds/MacOSX/includes/ParallelBufferPrinter.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/ParallelBufferPrinter.hpp
@@ -3,8 +3,8 @@
 //
 
 
-#ifndef FP_PARALLELBUFFERPRINTER_HPP
-#define FP_PARALLELBUFFERPRINTER_HPP
+#pragma once
+
 
 #include <fp_include_all.hpp>
 #include <JuceHeader.h>
@@ -62,8 +62,3 @@ private:
 };
 	
 } // fp
-
-
-#endif /* FP_PARALLELBUFFERPRINTER_HPP */
-
-

--- a/IRBaboonCombined/Builds/MacOSX/includes/fp_include_all.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/fp_include_all.hpp
@@ -7,8 +7,8 @@
  * and also houses several useful general definitions.
  */
 
-#ifndef FP_INCLUDE_ALL_HPP
-#define FP_INCLUDE_ALL_HPP
+#pragma once
+
 
 #include <stdio.h>
 #include <iostream>
@@ -31,5 +31,3 @@ using namespace fp;
 
 #define BREAK JUCE_BREAK_IN_DEBUGGER
 
-
-#endif /* FP_INCLUDE_ALL_HPP */

--- a/IRBaboonCombined/Builds/MacOSX/includes/fp_include_all.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/fp_include_all.hpp
@@ -1,5 +1,5 @@
 /* 
- * Copyright © 2020 Flixor. All rights reserved.
+ * Copyright © 2020 Flixor. 
  *
  * The fp namespace is to encompass all custom functions and classes,
  * as a sort of library-in-development.

--- a/IRBaboonCombined/Builds/MacOSX/includes/tools.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/tools.hpp
@@ -3,8 +3,8 @@
 //
 
 
-#ifndef FP_TOOLS_HPP
-#define FP_TOOLS_HPP
+#pragma once
+
 
 #include <fp_include_all.hpp>
 #include <JuceHeader.h>
@@ -81,4 +81,4 @@ namespace tools {
 } // tools
 } // fp
 
-#endif /* FP_TOOLS_HPP */
+

--- a/IRBaboonCombined/Builds/MacOSX/includes/tools.hpp
+++ b/IRBaboonCombined/Builds/MacOSX/includes/tools.hpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/CircularBufferArray.cpp
+++ b/IRBaboonCombined/Source/CircularBufferArray.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma.
 //
 
 

--- a/IRBaboonCombined/Source/Convolver.cpp
+++ b/IRBaboonCombined/Source/Convolver.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma.
 //
 
 

--- a/IRBaboonCombined/Source/Convolver.cpp
+++ b/IRBaboonCombined/Source/Convolver.cpp
@@ -360,18 +360,18 @@ AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<f
 	AudioSampleBuffer denomBuf (*denominatorBuffer);
 	denomBuf.setSize(1, denomBuf.getNumSamples(), true);
 
-	// match buffer lengths
+	/* match buffer lengths */
 	if (numBuf.getNumSamples() > denomBuf.getNumSamples())
 		denomBuf.setSize(denomBuf.getNumChannels(), numBuf.getNumSamples(), true);
 	else if (numBuf.getNumSamples() < denomBuf.getNumSamples())
 		numBuf.setSize(numBuf.getNumChannels(), denomBuf.getNumSamples(), true);
 
-	// FFT
+	/* FFT */
 	AudioSampleBuffer numBufFft (fftTransform(numBuf));
 	AudioSampleBuffer denomBufFft (fftTransform(denomBuf));
 
 
-	// DSP loop
+	/* DSP loop */
 	int N = numBufFft.getNumSamples() / 2;
 	float* numBufFftPtr = numBufFft.getWritePointer(0, 0);
 	const float* denomBufFftPtr = denomBufFft.getReadPointer(0, 0);

--- a/IRBaboonCombined/Source/Convolver.cpp
+++ b/IRBaboonCombined/Source/Convolver.cpp
@@ -353,7 +353,7 @@ AudioBuffer<float> convolveNonPeriodic(AudioSampleBuffer& buffer1, AudioSampleBu
 
 
 
-AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<float>* denominatorBuffer, double sampleRate, bool smoothing, bool nullifyPhase, bool nullifyAmplitude){
+AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<float>* denominatorBuffer, double sampleRate, bool smoothing, bool includePhase, bool includeAmplitude){
 	
 	AudioSampleBuffer numBuf (*numeratorBuffer);
 	numBuf.setSize(1, numBuf.getNumSamples(), true);
@@ -393,13 +393,11 @@ AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<f
 	 */
 	if (smoothing){
 		float smoothPerAvg = 1.0/13.0;
-		
-		averagingFilter(&numBufFft, smoothPerAvg, sampleRate, true, nullifyPhase, nullifyAmplitude);
-		averagingFilter(&numBufFft, smoothPerAvg, sampleRate, true, nullifyPhase, nullifyAmplitude);
-		averagingFilter(&numBufFft, smoothPerAvg, sampleRate, true, nullifyPhase, nullifyAmplitude);
+		for (int i = 0; i < 3; i++) {
+			averagingFilter(&numBufFft, smoothPerAvg, sampleRate, true, includePhase, includeAmplitude);
+		}
 	}
 
-	
 	/* IFFT */
 	numBuf = fftInvTransform(numBufFft);
 	
@@ -410,7 +408,7 @@ AudioBuffer<float> deconvolve(AudioBuffer<float>* numeratorBuffer, AudioBuffer<f
 													   
 													   
 
-void averagingFilter (AudioSampleBuffer* buffer, double octaveFraction, double sampleRate, bool logAvg, bool nullifyPhase, bool nullifyAmplitude){
+void averagingFilter (AudioSampleBuffer* buffer, double octaveFraction, double sampleRate, bool logAvg, bool includePhase, bool includeAmplitude){
 	
 	
 	int fftSize = buffer->getNumSamples();
@@ -541,8 +539,8 @@ void averagingFilter (AudioSampleBuffer* buffer, double octaveFraction, double s
 			tools::roundToZero(bufPtr + bin, 1e-11);	// rounding only seems necessary for determining phase per bin
 			tools::roundToZero(bufPtr + bin + 1, 1e-11);
 			float phase = tools::binPhase(bufPtr + bin);
-			if (nullifyAmplitude) ampl = 1.0;
-			if (nullifyPhase) phase = 0.0;
+			if (not includeAmplitude) ampl = 1.0;
+			if (not includePhase) phase = 0.0;
 			float re = ampl * cos(phase);
 			float im = ampl * sin(phase);
 			*(bufPtr + bin) = re;

--- a/IRBaboonCombined/Source/ExpSineSweep.cpp
+++ b/IRBaboonCombined/Source/ExpSineSweep.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/ParallelBufferPrinter.cpp
+++ b/IRBaboonCombined/Source/ParallelBufferPrinter.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -109,7 +109,9 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	addAndMakeVisible(&sliderZoomTarg);
 	sliderZoomTarg.setRange(-6, 60);
 	sliderZoomTarg.setValue(0.0);
-	sliderZoomTarg.onValueChange = [this] { processor.setZoomTarg(sliderZoomTarg.getValue()); };
+	sliderZoomTarg.onValueChange = [this] {
+		processor.setZoomTarg(sliderZoomTarg.getValue());
+	};
 
 	addAndMakeVisible(sliderZoomTargLabel);
 	sliderZoomTargLabel.setText("Target zoom [dB]", dontSendNotification);
@@ -118,7 +120,9 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	addAndMakeVisible(&sliderZoomBase);
 	sliderZoomBase.setRange(-6, 60);
 	sliderZoomBase.setValue(0.0);
-	sliderZoomBase.onValueChange = [this] { processor.setZoomBase(sliderZoomBase.getValue()); };
+	sliderZoomBase.onValueChange = [this] {
+		processor.setZoomBase(sliderZoomBase.getValue());
+	};
 	
 	addAndMakeVisible(sliderZoomBaseLabel);
 	sliderZoomBaseLabel.setText("Base zoom [dB]", dontSendNotification);
@@ -127,7 +131,9 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	addAndMakeVisible(&sliderZoomFilt);
 	sliderZoomFilt.setRange(-60, 36);
 	sliderZoomFilt.setValue(0.0);
-	sliderZoomFilt.onValueChange = [this] { processor.setZoomFilt(sliderZoomFilt.getValue()); };
+	sliderZoomFilt.onValueChange = [this] {
+		processor.setZoomFilt(sliderZoomFilt.getValue());
+	};
 	
 	addAndMakeVisible(sliderZoomFiltLabel);
 	sliderZoomFiltLabel.setText("Filter zoom [dB]", dontSendNotification);
@@ -136,7 +142,10 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	addAndMakeVisible(&outputVolumeSlider);
 	outputVolumeSlider.setRange(-60, 0);
 	outputVolumeSlider.setValue(0.0);
-	outputVolumeSlider.onValueChange = [this] { processor.setOutputVolume(outputVolumeSlider.getValue()); };
+	outputVolumeSlider.onValueChange = [this] {
+		processor.setOutputVolume(outputVolumeSlider.getValue());
+	};
+	processor.setOutputVolume(outputVolumeSlider.getValue()); // set starting value immediately
 
 	addAndMakeVisible(outputVolumeSliderLabel);
 	outputVolumeSliderLabel.setText("Output volume [dB]", dontSendNotification);
@@ -150,11 +159,15 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	
 	addAndMakeVisible (&phaseButton);
 	phaseButton.setToggleState(true, dontSendNotification);
-	phaseButton.onClick = [this] { processor.setPhaseFilt(phaseButton.getToggleState()); };
+	phaseButton.onClick = [this] {
+		processor.setPhaseFilt(phaseButton.getToggleState());
+	};
 	
 	addAndMakeVisible(&amplButton);
 	amplButton.setToggleState(true, dontSendNotification);
-	amplButton.onClick = [this] { processor.setAmplFilt(amplButton.getToggleState()); };
+	amplButton.onClick = [this] {
+		processor.setAmplFilt(amplButton.getToggleState());
+	};
 
 	
 	addAndMakeVisible(&presweepSilenceMenu);
@@ -228,7 +241,6 @@ void IRBaboonAudioProcessorEditor::timerCallback(){
 		makeupSizeMenu.setVisible(true);
 	}
 
-	
 	// thumbnails
 	String nameTarg (processor.getPrintDirectoryDebug() + "thumbnailTarg.wav");
 	File fileTarg (nameTarg);

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -22,7 +22,7 @@ String DecibelSlider::getTextFromValue (double value){
 
 
 //==============================================================================
-AutoKalibraDemoAudioProcessorEditor::AutoKalibraDemoAudioProcessorEditor (AutoKalibraDemoAudioProcessor& p)
+IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcessor& p)
     : AudioProcessorEditor (&p), processor (p),
 		thumbnailCacheTarg (1),
 		thumbnailCacheBase (1),
@@ -191,14 +191,14 @@ AutoKalibraDemoAudioProcessorEditor::AutoKalibraDemoAudioProcessorEditor (AutoKa
 	loadTargetButton.onClick = [this] { loadTargetClicked(); };
 }
 
-AutoKalibraDemoAudioProcessorEditor::~AutoKalibraDemoAudioProcessorEditor()
+IRBaboonAudioProcessorEditor::~IRBaboonAudioProcessorEditor()
 {
 }
 
 
 
-void AutoKalibraDemoAudioProcessorEditor::setStartCaptureTarget(){
-	processor.startCapture(AutoKalibraDemoAudioProcessor::IR_TARGET);
+void IRBaboonAudioProcessorEditor::setStartCaptureTarget(){
+	processor.startCapture(IRBaboonAudioProcessor::IR_TARGET);
 	captureBaseButton.setVisible(false);
 	presweepSilenceMenu.setVisible(false);
 	int ms = std::ceil( 1000 * ((float) processor.getTotalSweepBreakSamples() + (float) presweepSilence) / ((float) processor.getSamplerate()) );
@@ -208,8 +208,8 @@ void AutoKalibraDemoAudioProcessorEditor::setStartCaptureTarget(){
 	} );
 }
 
-void AutoKalibraDemoAudioProcessorEditor::setStartCaptureBase(){
-	processor.startCapture(AutoKalibraDemoAudioProcessor::IR_BASE);
+void IRBaboonAudioProcessorEditor::setStartCaptureBase(){
+	processor.startCapture(IRBaboonAudioProcessor::IR_BASE);
 	captureTargButton.setVisible(false);
 	presweepSilenceMenu.setVisible(false);
 	int ms = std::ceil( 1000 * ((float) processor.getTotalSweepBreakSamples() + (float) presweepSilence) / ((float) processor.getSamplerate()) );
@@ -221,7 +221,7 @@ void AutoKalibraDemoAudioProcessorEditor::setStartCaptureBase(){
 
 
 
-void AutoKalibraDemoAudioProcessorEditor::timerCallback(){
+void IRBaboonAudioProcessorEditor::timerCallback(){
 	// filt button
 	if (processor.filtReady()){
 		playFiltAudioButton.setVisible(true);
@@ -257,7 +257,7 @@ void AutoKalibraDemoAudioProcessorEditor::timerCallback(){
 }
 
 
-void AutoKalibraDemoAudioProcessorEditor::playUnprocessedAudioClick (bool toggleState){
+void IRBaboonAudioProcessorEditor::playUnprocessedAudioClick (bool toggleState){
 	processor.setPlayFiltered(false);
 	
 	if (toggleState) playUnprocessedAudioButton.setButtonText("PLAYING unprocessed audio");
@@ -266,7 +266,7 @@ void AutoKalibraDemoAudioProcessorEditor::playUnprocessedAudioClick (bool toggle
 
 
 
-void AutoKalibraDemoAudioProcessorEditor::playFiltAudioClick (bool toggleState){
+void IRBaboonAudioProcessorEditor::playFiltAudioClick (bool toggleState){
 	processor.setPlayFiltered(true);
 
 	if (toggleState) {
@@ -278,7 +278,7 @@ void AutoKalibraDemoAudioProcessorEditor::playFiltAudioClick (bool toggleState){
 
 
 
-void AutoKalibraDemoAudioProcessorEditor::loadTargetClicked(){
+void IRBaboonAudioProcessorEditor::loadTargetClicked(){
 	FileChooser myChooser ("Please select the sweepandir you want to load...",
 						   File("../../../../../Saved IRs"),
 						   String("*" + processor.getSavedIRExtension()));
@@ -288,7 +288,7 @@ void AutoKalibraDemoAudioProcessorEditor::loadTargetClicked(){
 }
 
 
-void AutoKalibraDemoAudioProcessorEditor::presweepSilenceMenuChanged(){
+void IRBaboonAudioProcessorEditor::presweepSilenceMenuChanged(){
 	
 	switch (presweepSilenceMenu.getSelectedId()){
 		case 1: presweepSilence = 4096;		break;
@@ -305,7 +305,7 @@ void AutoKalibraDemoAudioProcessorEditor::presweepSilenceMenuChanged(){
 }
 
 
-void AutoKalibraDemoAudioProcessorEditor::makeupSizeMenuChanged(){
+void IRBaboonAudioProcessorEditor::makeupSizeMenuChanged(){
 	
 	switch (makeupSizeMenu.getSelectedId()){
 		case 1: makeupSize = 128;	break;
@@ -325,7 +325,7 @@ void AutoKalibraDemoAudioProcessorEditor::makeupSizeMenuChanged(){
 }
 
 
-void AutoKalibraDemoAudioProcessorEditor::changeListenerCallback(ChangeBroadcaster* source){
+void IRBaboonAudioProcessorEditor::changeListenerCallback(ChangeBroadcaster* source){
 	repaint();
 }
 
@@ -334,7 +334,7 @@ void AutoKalibraDemoAudioProcessorEditor::changeListenerCallback(ChangeBroadcast
 
 
 //==============================================================================
-void AutoKalibraDemoAudioProcessorEditor::paint (Graphics& g)
+void IRBaboonAudioProcessorEditor::paint (Graphics& g)
 {
 	
 	/* Target thumbnail */
@@ -424,7 +424,7 @@ void AutoKalibraDemoAudioProcessorEditor::paint (Graphics& g)
 
 
 
-void AutoKalibraDemoAudioProcessorEditor::resized()
+void IRBaboonAudioProcessorEditor::resized()
 {
     // This is generally where you'll want to lay out the positions of any
     // subcomponents in your editor..

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -146,15 +146,15 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 	/* bottom buttons */
 	addAndMakeVisible(&toggleButtonLabel);
 	toggleButtonLabel.setText("Filter:", dontSendNotification);
-	toggleButtonLabel.attachToComponent(&nullifyAmplitudeButton, true);
+	toggleButtonLabel.attachToComponent(&amplButton, true);
 	
-	addAndMakeVisible (&nullifyPhaseButton);
-	nullifyPhaseButton.setToggleState(true, dontSendNotification);
-	nullifyPhaseButton.onClick = [this] { processor.setNullifyPhaseFilt(!nullifyPhaseButton.getToggleState()); }; // NEGATIVE because GUI implies activation, but functions are implemented as 'nullify'... code needs to be more clear
+	addAndMakeVisible (&phaseButton);
+	phaseButton.setToggleState(true, dontSendNotification);
+	phaseButton.onClick = [this] { processor.setPhaseFilt(phaseButton.getToggleState()); };
 	
-	addAndMakeVisible(&nullifyAmplitudeButton);
-	nullifyAmplitudeButton.setToggleState(true, dontSendNotification);
-	nullifyAmplitudeButton.onClick = [this] { processor.setNullifyAmplFilt(!nullifyAmplitudeButton.getToggleState()); }; // NEGATIVE because GUI implies activation, but functions are implemented as 'nullify'... code needs to be more clear
+	addAndMakeVisible(&amplButton);
+	amplButton.setToggleState(true, dontSendNotification);
+	amplButton.onClick = [this] { processor.setAmplFilt(amplButton.getToggleState()); };
 
 	
 	addAndMakeVisible(&presweepSilenceMenu);
@@ -477,11 +477,11 @@ void IRBaboonAudioProcessorEditor::resized()
 
 
 	// bottom buttons
-	nullifyAmplitudeButton.setBounds(getLocalBounds().getWidth() * 1/12,
+	amplButton.setBounds(getLocalBounds().getWidth() * 1/12,
 								 getLocalBounds().getHeight() - buttonHeight,
 								 getLocalBounds().getWidth() * 1/12,
 								 buttonHeight);
-	nullifyPhaseButton.setBounds(getLocalBounds().getWidth() * 2/12 ,
+	phaseButton.setBounds(getLocalBounds().getWidth() * 2/12 ,
 								 getLocalBounds().getHeight() - buttonHeight,
 								 getLocalBounds().getWidth() * 1/12,
 								 buttonHeight);

--- a/IRBaboonCombined/Source/PluginEditor.cpp
+++ b/IRBaboonCombined/Source/PluginEditor.cpp
@@ -135,7 +135,7 @@ IRBaboonAudioProcessorEditor::IRBaboonAudioProcessorEditor (IRBaboonAudioProcess
 
 	addAndMakeVisible(&outputVolumeSlider);
 	outputVolumeSlider.setRange(-60, 0);
-	outputVolumeSlider.setValue(-20.0);
+	outputVolumeSlider.setValue(0.0);
 	outputVolumeSlider.onValueChange = [this] { processor.setOutputVolume(outputVolumeSlider.getValue()); };
 
 	addAndMakeVisible(outputVolumeSliderLabel);

--- a/IRBaboonCombined/Source/PluginEditor.h
+++ b/IRBaboonCombined/Source/PluginEditor.h
@@ -11,7 +11,7 @@
 
 
 /*
- * Coped straight from Juce decibel slider tutorial
+ * Copied straight from Juce decibel slider tutorial
  */
 class DecibelSlider : public Slider
 {
@@ -103,8 +103,8 @@ private:
 	int sliderHeightMargin = 10;
 	
 	Label toggleButtonLabel;
-	ToggleButton nullifyPhaseButton { "Phase" };
-	ToggleButton nullifyAmplitudeButton { "EQ" };
+	ToggleButton phaseButton { "Phase" };
+	ToggleButton amplButton { "EQ" };
 	ComboBox presweepSilenceMenu;
 	int presweepSilence = 16384;
 	ComboBox makeupSizeMenu;

--- a/IRBaboonCombined/Source/PluginEditor.h
+++ b/IRBaboonCombined/Source/PluginEditor.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/PluginEditor.h
+++ b/IRBaboonCombined/Source/PluginEditor.h
@@ -26,17 +26,13 @@ private:
 
 
 
-//==============================================================================
-/**
-*/
-class AutoKalibraDemoAudioProcessorEditor  : public AudioProcessorEditor,
+class IRBaboonAudioProcessorEditor  : public AudioProcessorEditor,
 											public Timer,
 											public ChangeListener
 {
 public:
-    AutoKalibraDemoAudioProcessorEditor (AutoKalibraDemoAudioProcessor&);
-    ~AutoKalibraDemoAudioProcessorEditor();
-	//==============================================================================
+    IRBaboonAudioProcessorEditor (IRBaboonAudioProcessor&);
+    ~IRBaboonAudioProcessorEditor();
 
 	void setStartCaptureTarget();
 	void setStartCaptureBase();
@@ -52,16 +48,14 @@ public:
 	/* thumbnails */
 	void changeListenerCallback(ChangeBroadcaster* source) override;
 	
-    //==============================================================================
     void paint (Graphics&) override;
-	
     void resized() override;
 	
 	
 private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
-    AutoKalibraDemoAudioProcessor& processor;
+    IRBaboonAudioProcessor& processor;
 
 	TextButton captureTargButton  { "Capture target IR" };
 	TextButton captureBaseButton  { "Capture base IR" };
@@ -122,5 +116,5 @@ private:
 	float refZoomLin = 1.0f;
 	
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AutoKalibraDemoAudioProcessorEditor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (IRBaboonAudioProcessorEditor)
 };

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -650,6 +650,8 @@ void IRBaboonAudioProcessor::run() {
 			saveIRCustomType = IR_NONE;
 		}
 		
+		printThumbnails();
+		
 		/* A negative timeout value means that the method will wait indefinitely (until notify() is called) */
 		wait (-1);
 	}
@@ -739,6 +741,21 @@ void IRBaboonAudioProcessor::printDebug() {
 	wavPrinter.appendBuffer(printNames[3], IRPrintBase);
 	wavPrinter.appendBuffer(printNames[4], IRPrintFilt);
 	
+	// print everything
+	wavPrinter.printToWav(0, wavPrinter.getMaxBufferLength(), sampleRate, printDirectoryDebug);
+}
+
+
+void IRBaboonAudioProcessor::printThumbnails() {
+	ParallelBufferPrinter wavPrinter;
+
+	/* dereference the buffers */
+	AudioSampleBuffer sweepPrintTarg (*(sweepTargPtr->getBuffer()));
+	AudioSampleBuffer IRPrintTarg (*(IRTargPtr->getBuffer()));
+	AudioSampleBuffer sweepPrintBase (*(sweepBasePtr->getBuffer()));
+	AudioSampleBuffer IRPrintBase (*(IRBasePtr->getBuffer()));
+	AudioSampleBuffer IRPrintFilt (*(IRFiltPtr->getBuffer()));
+	
 	// create target sweep & IR file for thumbnail
 	AudioSampleBuffer thumbnailTarg (2, std::max(sweepPrintTarg.getNumSamples(), IRPrintTarg.getNumSamples()));
 	thumbnailTarg.clear();
@@ -749,13 +766,13 @@ void IRBaboonAudioProcessor::printDebug() {
 	thumbnailTarg.applyGain(tools::dBToLin(zoomTargdB));
 	wavPrinter.appendBuffer("thumbnailTarg", thumbnailTarg);
 	
-	// delete thumbnail file again if it has been swaped with empty current
+	// delete thumbnail file again if it has been swapped with empty current
 	String nameTarg (printDirectoryDebug + "thumbnailTarg.wav");
 	File fileTarg (nameTarg);
 	if (thumbnailTarg.getNumSamples() == 0 && fileTarg.existsAsFile()){
 		fileTarg.deleteFile();
 	}
-
+	
 	// create current sweep & IR file for thumbnail
 	AudioSampleBuffer currentForThumbnail (2, std::max(sweepPrintBase.getNumSamples(), IRPrintBase.getNumSamples()));
 	currentForThumbnail.clear();
@@ -765,14 +782,14 @@ void IRBaboonAudioProcessor::printDebug() {
 		currentForThumbnail.copyFrom(1, 0, IRPrintBase, 0, 0, IRPrintBase.getNumSamples());
 	currentForThumbnail.applyGain(tools::dBToLin(zoomBasedB));
 	wavPrinter.appendBuffer("thumbnailBase", currentForThumbnail);
-
-	// delete thumbnail file again if it has been swaped with empty reference
+	
+	// delete thumbnail file again if it has been swapped with empty reference
 	String nameCurrent (printDirectoryDebug + "thumbnailBase.wav");
 	File fileCurrent (nameCurrent);
 	if (currentForThumbnail.getNumSamples() == 0 && fileCurrent.existsAsFile()){
 		fileCurrent.deleteFile();
 	}
-
+	
 	// create makeup IR file for thumbnail
 	AudioSampleBuffer InvfiltForThumbnail (1, IRPrintFilt.getNumSamples());
 	if (IRPrintFilt.getNumSamples() > 0)

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -604,13 +604,10 @@ void IRBaboonAudioProcessor::startCapture(IRType type){
 
 
 void IRBaboonAudioProcessor::createIRFilt(){
-	AudioSampleBuffer IR;
 	
-	IR.makeCopyOf(convolver::deconvolve(IRTargPtr->getBuffer(), IRBasePtr->getBuffer(), sampleRate, true, includePhaseFilt, includeAmplFilt));
+	IRFiltPtr->getBuffer()->makeCopyOf(convolver::deconvolve(IRTargPtr->getBuffer(), IRBasePtr->getBuffer(), sampleRate, true, includePhaseFilt, includeAmplFilt));
 
-	if (not includePhaseFilt) convolver::shifteroo(&IR);
-	
-	IRFiltPtr->getBuffer()->makeCopyOf(IR);
+	if (not includePhaseFilt) convolver::shifteroo(IRFiltPtr->getBuffer());
 }
 
 

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -303,13 +303,13 @@ void IRBaboonAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffe
 			
 			if (IRCapture.type == IR_TARGET) {
 				sweepTargPtr->getBuffer()->makeCopyOf(inputCaptureArray.consolidate(0));
-				IRTargPtr->getBuffer()->makeCopyOf(createIR(*sweepTargPtr->getBuffer(), sweepBufForDeconv));
+				IRTargPtr->getBuffer()->makeCopyOf(convolver::deconvolve(sweepTargPtr->getBuffer(), &sweepBufForDeconv, sampleRate));
 
 				saveIRCustomType = IR_TARGET;
 			}
 			else if (IRCapture.type == IR_BASE) {
 				sweepBasePtr->getBuffer()->makeCopyOf(inputCaptureArray.consolidate(0));
-				IRBasePtr->getBuffer()->makeCopyOf(createIR(*sweepBasePtr->getBuffer(), sweepBufForDeconv));
+				IRBasePtr->getBuffer()->makeCopyOf(convolver::deconvolve(sweepBasePtr->getBuffer(), &sweepBufForDeconv, sampleRate));
 
 				saveIRCustomType = IR_BASE;
 			}
@@ -591,7 +591,6 @@ void IRBaboonAudioProcessor::processBlockBypassed(AudioBuffer<float>& buffer, Mi
 
 
 
-
 void IRBaboonAudioProcessor::startCapture(IRType type){
 	if (type == IR_NONE) return;
 	
@@ -600,12 +599,6 @@ void IRBaboonAudioProcessor::startCapture(IRType type){
 	IRCapture.doFadeout = true;
 
 	buffersWaitForInputCapture = samplesWaitBeforeInputCapture / processBlockSize;
-}
-
-
-
-AudioSampleBuffer IRBaboonAudioProcessor::createIR(AudioSampleBuffer& numeratorBuf, AudioSampleBuffer& denominatorBuf){
-	return convolver::deconvolve(&numeratorBuf, &denominatorBuf, sampleRate);
 }
 
 

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -613,13 +613,9 @@ AudioSampleBuffer IRBaboonAudioProcessor::createIR(AudioSampleBuffer& numeratorB
 void IRBaboonAudioProcessor::createIRFilt(){
 	AudioSampleBuffer IR;
 	
-	IR.makeCopyOf(convolver::deconvolve(IRTargPtr->getBuffer(), IRBasePtr->getBuffer(), sampleRate, true, nullifyPhaseFilt, nullifyAmplFilt));
+	IR.makeCopyOf(convolver::deconvolve(IRTargPtr->getBuffer(), IRBasePtr->getBuffer(), sampleRate, true, includePhaseFilt, includeAmplFilt));
 
-	if (nullifyPhaseFilt) convolver::shifteroo(&IR);
-	
-	ParallelBufferPrinter printer;
-	printer.appendBuffer("IRFilt unchopped", IR);
-	printer.printToWav(0, printer.getMaxBufferLength(), sampleRate, printDirectoryDebug);
+	if (not includePhaseFilt) convolver::shifteroo(&IR);
 	
 	IRFiltPtr->getBuffer()->makeCopyOf(IR);
 	
@@ -836,8 +832,8 @@ void IRBaboonAudioProcessor::setOutputVolume(float dB){
 }
 
 
-void IRBaboonAudioProcessor::setNullifyPhaseFilt(bool nullifyPhase){
-	nullifyPhaseFilt = nullifyPhase;
+void IRBaboonAudioProcessor::setPhaseFilt(bool includePhase){
+	includePhaseFilt = includePhase;
 	
 	if (IRTargPtr->bufferNotEmpty() && IRBasePtr->bufferNotEmpty()){
 		createIRFilt();
@@ -847,8 +843,8 @@ void IRBaboonAudioProcessor::setNullifyPhaseFilt(bool nullifyPhase){
 }
 
 
-void IRBaboonAudioProcessor::setNullifyAmplFilt(bool nullifyAmplitude){
-	nullifyAmplFilt = nullifyAmplitude;
+void IRBaboonAudioProcessor::setAmplFilt(bool includeAmplitude){
+	includeAmplFilt = includeAmplitude;
 	
 	if (IRTargPtr->bufferNotEmpty() && IRBasePtr->bufferNotEmpty()){
 		createIRFilt();

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -8,11 +8,7 @@
 
 
 
-//==============================================================================
-// AutoKalibraDemoAudioProcessor
-//==============================================================================
-
-AutoKalibraDemoAudioProcessor::AutoKalibraDemoAudioProcessor()
+IRBaboonAudioProcessor::IRBaboonAudioProcessor()
      : AudioProcessor (BusesProperties()
 					   .withInput  ("Input",  AudioChannelSet::stereo(), true)
 					   .withOutput ("Output", AudioChannelSet::stereo(), true)
@@ -90,7 +86,7 @@ AutoKalibraDemoAudioProcessor::AutoKalibraDemoAudioProcessor()
 	
 }
 
-AutoKalibraDemoAudioProcessor::~AutoKalibraDemoAudioProcessor()
+IRBaboonAudioProcessor::~IRBaboonAudioProcessor()
 {
 	delete fftIR;
 	delete fftForward;
@@ -100,12 +96,12 @@ AutoKalibraDemoAudioProcessor::~AutoKalibraDemoAudioProcessor()
 }
 
 //==============================================================================
-const String AutoKalibraDemoAudioProcessor::getName() const
+const String IRBaboonAudioProcessor::getName() const
 {
     return JucePlugin_Name;
 }
 
-bool AutoKalibraDemoAudioProcessor::acceptsMidi() const
+bool IRBaboonAudioProcessor::acceptsMidi() const
 {
    #if JucePlugin_WantsMidiInput
     return true;
@@ -114,7 +110,7 @@ bool AutoKalibraDemoAudioProcessor::acceptsMidi() const
    #endif
 }
 
-bool AutoKalibraDemoAudioProcessor::producesMidi() const
+bool IRBaboonAudioProcessor::producesMidi() const
 {
    #if JucePlugin_ProducesMidiOutput
     return true;
@@ -123,7 +119,7 @@ bool AutoKalibraDemoAudioProcessor::producesMidi() const
    #endif
 }
 
-bool AutoKalibraDemoAudioProcessor::isMidiEffect() const
+bool IRBaboonAudioProcessor::isMidiEffect() const
 {
    #if JucePlugin_IsMidiEffect
     return true;
@@ -132,32 +128,32 @@ bool AutoKalibraDemoAudioProcessor::isMidiEffect() const
    #endif
 }
 
-double AutoKalibraDemoAudioProcessor::getTailLengthSeconds() const
+double IRBaboonAudioProcessor::getTailLengthSeconds() const
 {
     return 0.0;
 }
 
-int AutoKalibraDemoAudioProcessor::getNumPrograms()
+int IRBaboonAudioProcessor::getNumPrograms()
 {
     return 1;   // NB: some hosts don't cope very well if you tell them there are 0 programs,
                 // so this should be at least 1, even if you're not really implementing programs.
 }
 
-int AutoKalibraDemoAudioProcessor::getCurrentProgram()
+int IRBaboonAudioProcessor::getCurrentProgram()
 {
     return 0;
 }
 
-void AutoKalibraDemoAudioProcessor::setCurrentProgram (int index)
+void IRBaboonAudioProcessor::setCurrentProgram (int index)
 {
 }
 
-const String AutoKalibraDemoAudioProcessor::getProgramName (int index)
+const String IRBaboonAudioProcessor::getProgramName (int index)
 {
     return {};
 }
 
-void AutoKalibraDemoAudioProcessor::changeProgramName (int index, const String& newName)
+void IRBaboonAudioProcessor::changeProgramName (int index, const String& newName)
 {
 }
 
@@ -165,7 +161,7 @@ void AutoKalibraDemoAudioProcessor::changeProgramName (int index, const String& 
 
 
 //==============================================================================
-void AutoKalibraDemoAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
+void IRBaboonAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
 	sampleRate = (int) sampleRate;
 	generalHostBlockSize = samplesPerBlock;
@@ -241,7 +237,7 @@ void AutoKalibraDemoAudioProcessor::prepareToPlay (double sampleRate, int sample
 
 
 
-void AutoKalibraDemoAudioProcessor::releaseResources()
+void IRBaboonAudioProcessor::releaseResources()
 {
     /* memory used by buffer arrays is freed up */
 	inputBufferArray.changeArraySize(0);
@@ -252,7 +248,7 @@ void AutoKalibraDemoAudioProcessor::releaseResources()
 }
 
 /* Boilerplate JUCE, to check whether channel layouts are supported. */
-bool AutoKalibraDemoAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+bool IRBaboonAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
     // In this template code we only support mono or stereo.
     if (layouts.getMainOutputChannelSet() != AudioChannelSet::mono()
@@ -270,7 +266,7 @@ bool AutoKalibraDemoAudioProcessor::isBusesLayoutSupported (const BusesLayout& l
 
 
 
-void AutoKalibraDemoAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& midiMessages)
+void IRBaboonAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& midiMessages)
 {
     ScopedNoDenormals noDenormals;
     auto totalNumOutputChannels = getTotalNumOutputChannels();
@@ -585,7 +581,7 @@ void AutoKalibraDemoAudioProcessor::processBlock (AudioBuffer<float>& buffer, Mi
 /* when plugin is bypassed, the latency of 1 processBlock should be maintained.
  * A CircularBufferArray is used for this.
  */
-void AutoKalibraDemoAudioProcessor::processBlockBypassed(AudioBuffer<float>& buffer, MidiBuffer& midiMessages)
+void IRBaboonAudioProcessor::processBlockBypassed(AudioBuffer<float>& buffer, MidiBuffer& midiMessages)
 {
 	bypassOutputBufferArray.getWriteBufferPtr()->makeCopyOf(buffer);
 	bypassOutputBufferArray.incrWriteIndex();
@@ -596,7 +592,7 @@ void AutoKalibraDemoAudioProcessor::processBlockBypassed(AudioBuffer<float>& buf
 
 
 
-void AutoKalibraDemoAudioProcessor::startCapture(IRType type){
+void IRBaboonAudioProcessor::startCapture(IRType type){
 	if (type == IR_NONE) return;
 	
 	IRCapture.type = type;
@@ -608,13 +604,13 @@ void AutoKalibraDemoAudioProcessor::startCapture(IRType type){
 
 
 
-AudioSampleBuffer AutoKalibraDemoAudioProcessor::createIR(AudioSampleBuffer& numeratorBuf, AudioSampleBuffer& denominatorBuf){
+AudioSampleBuffer IRBaboonAudioProcessor::createIR(AudioSampleBuffer& numeratorBuf, AudioSampleBuffer& denominatorBuf){
 	return convolver::deconvolve(&numeratorBuf, &denominatorBuf, sampleRate, true, false);
 }
 
 
 
-void AutoKalibraDemoAudioProcessor::createIRFilt(){
+void IRBaboonAudioProcessor::createIRFilt(){
 	AudioSampleBuffer IR;
 	
 	IR.makeCopyOf(convolver::deconvolve(IRTargPtr->getBuffer(), IRBasePtr->getBuffer(), sampleRate, true, nullifyPhaseFilt, nullifyAmplFilt));
@@ -632,36 +628,36 @@ void AutoKalibraDemoAudioProcessor::createIRFilt(){
 }
 
 
-int AutoKalibraDemoAudioProcessor::getTotalSweepBreakSamples(){
+int IRBaboonAudioProcessor::getTotalSweepBreakSamples(){
 	return totalSweepBreakSamples;
 }
 
-int AutoKalibraDemoAudioProcessor::getMakeupIRLengthSamples(){
+int IRBaboonAudioProcessor::getMakeupIRLengthSamples(){
 	return makeupIRLengthSamples;
 }
 
-int AutoKalibraDemoAudioProcessor::getSamplerate(){
+int IRBaboonAudioProcessor::getSamplerate(){
 	return sampleRate;
 }
 
 
-bool AutoKalibraDemoAudioProcessor::filtReady(){
+bool IRBaboonAudioProcessor::filtReady(){
 	return (IRFiltPtr->bufferNotEmpty());
 }
 
 
-AudioSampleBuffer AutoKalibraDemoAudioProcessor::getIRFilt(){
+AudioSampleBuffer IRBaboonAudioProcessor::getIRFilt(){
 	return *IRFiltPtr->getBuffer();
 }
 
 
-void AutoKalibraDemoAudioProcessor::setPlayFiltered (bool filtered){
+void IRBaboonAudioProcessor::setPlayFiltered (bool filtered){
 	playFiltered = filtered;
 }
 
 
 
-void AutoKalibraDemoAudioProcessor::run() {
+void IRBaboonAudioProcessor::run() {
 	while (NOT threadShouldExit()) {
 		
 		saveCustomExt(saveIRCustomType);
@@ -678,7 +674,7 @@ void AutoKalibraDemoAudioProcessor::run() {
 
 
 
-void AutoKalibraDemoAudioProcessor::saveCustomExt(IRType type){
+void IRBaboonAudioProcessor::saveCustomExt(IRType type){
 	
 	AudioSampleBuffer savebuf (2, totalSweepBreakSamples);
 	std::string name = getDateTimeString();
@@ -714,7 +710,7 @@ void AutoKalibraDemoAudioProcessor::saveCustomExt(IRType type){
 
 
 
-std::string AutoKalibraDemoAudioProcessor::getDateTimeString(){
+std::string IRBaboonAudioProcessor::getDateTimeString(){
 	std::time_t now = std::time(NULL);
 	std::tm* ptm = std::localtime(&now);
 	char date[32];
@@ -725,7 +721,7 @@ std::string AutoKalibraDemoAudioProcessor::getDateTimeString(){
 
 
 
-void AutoKalibraDemoAudioProcessor::printDebug() {
+void IRBaboonAudioProcessor::printDebug() {
 	ParallelBufferPrinter wavPrinter;
 	ParallelBufferPrinter freqPrinter;
 
@@ -806,41 +802,41 @@ void AutoKalibraDemoAudioProcessor::printDebug() {
 }
 
 
-std::string AutoKalibraDemoAudioProcessor::getPrintDirectoryDebug(){
+std::string IRBaboonAudioProcessor::getPrintDirectoryDebug(){
 	return printDirectoryDebug;
 }
 
 
-std::string AutoKalibraDemoAudioProcessor::getSavedIRExtension(){
+std::string IRBaboonAudioProcessor::getSavedIRExtension(){
 	return savedIRExtension;
 }
 
 
-void AutoKalibraDemoAudioProcessor::setZoomTarg(float dB){
+void IRBaboonAudioProcessor::setZoomTarg(float dB){
 	zoomTargdB = dB;
 	notify();
 }
 
 
-void AutoKalibraDemoAudioProcessor::setZoomBase(float dB){
+void IRBaboonAudioProcessor::setZoomBase(float dB){
 	zoomBasedB = dB;
 	notify();
 }
 
 
-void AutoKalibraDemoAudioProcessor::setZoomFilt(float dB){
+void IRBaboonAudioProcessor::setZoomFilt(float dB){
 	zoomFiltdB = dB;
 	notify();
 }
 
 
-void AutoKalibraDemoAudioProcessor::setOutputVolume(float dB){
+void IRBaboonAudioProcessor::setOutputVolume(float dB){
 	outputVolumedB = dB;
 	tools::normalize(&sweepBufForDeconv, outputVolumedB + sweepLeveldB);
 }
 
 
-void AutoKalibraDemoAudioProcessor::setNullifyPhaseFilt(bool nullifyPhase){
+void IRBaboonAudioProcessor::setNullifyPhaseFilt(bool nullifyPhase){
 	nullifyPhaseFilt = nullifyPhase;
 	
 	if (IRTargPtr->bufferNotEmpty() && IRBasePtr->bufferNotEmpty()){
@@ -851,7 +847,7 @@ void AutoKalibraDemoAudioProcessor::setNullifyPhaseFilt(bool nullifyPhase){
 }
 
 
-void AutoKalibraDemoAudioProcessor::setNullifyAmplFilt(bool nullifyAmplitude){
+void IRBaboonAudioProcessor::setNullifyAmplFilt(bool nullifyAmplitude){
 	nullifyAmplFilt = nullifyAmplitude;
 	
 	if (IRTargPtr->bufferNotEmpty() && IRBasePtr->bufferNotEmpty()){
@@ -862,12 +858,12 @@ void AutoKalibraDemoAudioProcessor::setNullifyAmplFilt(bool nullifyAmplitude){
 }
 
 
-void AutoKalibraDemoAudioProcessor::setPresweepSilence(int presweepSilence){
+void IRBaboonAudioProcessor::setPresweepSilence(int presweepSilence){
 	samplesWaitBeforeInputCapture = presweepSilence;
 }
 
 
-void AutoKalibraDemoAudioProcessor::setMakeupSize(int makeupSize){
+void IRBaboonAudioProcessor::setMakeupSize(int makeupSize){
 	makeupIRLengthSamples = makeupSize;
 	
 	if (IRTargPtr->bufferNotEmpty() && IRBasePtr->bufferNotEmpty()){
@@ -878,7 +874,7 @@ void AutoKalibraDemoAudioProcessor::setMakeupSize(int makeupSize){
 }
 
 
-void AutoKalibraDemoAudioProcessor::swapTargetBase(){
+void IRBaboonAudioProcessor::swapTargetBase(){
 	
 	AudioSampleBuffer savedSweep (*(sweepTargPtr->getBuffer()));
 	AudioSampleBuffer savedIR (*(IRTargPtr->getBuffer()));
@@ -897,7 +893,7 @@ void AutoKalibraDemoAudioProcessor::swapTargetBase(){
 }
 
 
-void AutoKalibraDemoAudioProcessor::loadTarget(File file){
+void IRBaboonAudioProcessor::loadTarget(File file){
 	
 	/* rename custom extension to .wav */
 	std::string pathCustomExtension = file.getFullPathName().toStdString();
@@ -933,25 +929,25 @@ void AutoKalibraDemoAudioProcessor::loadTarget(File file){
 
 
 //==============================================================================
-bool AutoKalibraDemoAudioProcessor::hasEditor() const
+bool IRBaboonAudioProcessor::hasEditor() const
 {
     return true; // (change this to false if you choose to not supply an editor)
 }
 
-AudioProcessorEditor* AutoKalibraDemoAudioProcessor::createEditor()
+AudioProcessorEditor* IRBaboonAudioProcessor::createEditor()
 {
-    return new AutoKalibraDemoAudioProcessorEditor (*this);
+    return new IRBaboonAudioProcessorEditor (*this);
 }
 
 //==============================================================================
-void AutoKalibraDemoAudioProcessor::getStateInformation (MemoryBlock& destData)
+void IRBaboonAudioProcessor::getStateInformation (MemoryBlock& destData)
 {
     // You should use this method to store your parameters in the memory block.
     // You could do that either as raw data, or use the XML or ValueTree classes
     // as intermediaries to make it easy to save and load complex data.
 }
 
-void AutoKalibraDemoAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
+void IRBaboonAudioProcessor::setStateInformation (const void* data, int sizeInBytes)
 {
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
@@ -961,5 +957,5 @@ void AutoKalibraDemoAudioProcessor::setStateInformation (const void* data, int s
 // This creates new instances of the plugin..
 AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
-    return new AutoKalibraDemoAudioProcessor();
+    return new IRBaboonAudioProcessor();
 }

--- a/IRBaboonCombined/Source/PluginProcessor.cpp
+++ b/IRBaboonCombined/Source/PluginProcessor.cpp
@@ -605,7 +605,7 @@ void IRBaboonAudioProcessor::startCapture(IRType type){
 
 
 AudioSampleBuffer IRBaboonAudioProcessor::createIR(AudioSampleBuffer& numeratorBuf, AudioSampleBuffer& denominatorBuf){
-	return convolver::deconvolve(&numeratorBuf, &denominatorBuf, sampleRate, true, false);
+	return convolver::deconvolve(&numeratorBuf, &denominatorBuf, sampleRate);
 }
 
 
@@ -618,9 +618,6 @@ void IRBaboonAudioProcessor::createIRFilt(){
 	if (not includePhaseFilt) convolver::shifteroo(&IR);
 	
 	IRFiltPtr->getBuffer()->makeCopyOf(IR);
-	
-//	AudioSampleBuffer IRinvfiltchop (convolver::IRchop(IRinvfilt, makeupIRLengthSamples, -24.0, 25));
-//	return IRinvfiltchop;
 }
 
 

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -82,7 +82,6 @@ public:
 
 	void startCapture(IRType type);
 
-	AudioSampleBuffer createIR(AudioSampleBuffer& numeratorBuf, AudioSampleBuffer& denominatorBuf);
 	void createIRFilt();
 	
 	int getTotalSweepBreakSamples();

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -108,8 +108,8 @@ public:
 	void setZoomFilt(float dB);
 	void setOutputVolume(float dB);
 	
-	void setNullifyPhaseFilt(bool nullifyPhase);
-	void setNullifyAmplFilt(bool nullifyAmplitude);
+	void setPhaseFilt(bool includePhase);
+	void setAmplFilt(bool includeAmplitude);
 	void setPresweepSilence(int presweepSilence);
 	void setMakeupSize(int makeupSize);
 	void swapTargetBase();
@@ -193,8 +193,8 @@ private:
 	float zoomBasedB = 0.0;
 	float zoomFiltdB = 0.0;
 	
-	bool nullifyPhaseFilt = false;
-	bool nullifyAmplFilt = false;
+	bool includePhaseFilt = true;
+	bool includeAmplFilt = true;
 
 	
 	

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -12,43 +12,41 @@
 
 
 
-class AutoKalibraDemoAudioProcessor  : public AudioProcessor, public Thread
+class IRBaboonAudioProcessor  : public AudioProcessor, public Thread
 {
 public:
 	
 	/* From Juce tutorial
 	 https://docs.juce.com/master/tutorial_looping_audio_sample_buffer_advanced.html
 	 */
-	class ReferenceCountedBuffer : public ReferenceCountedObject
-	{
-	public:
-		typedef ReferenceCountedObjectPtr<ReferenceCountedBuffer> Ptr;
-		ReferenceCountedBuffer (const String& nameToUse, AudioSampleBuffer buf)
-		: name (nameToUse), buffer (buf) {
-		}
+	class ReferenceCountedBuffer : public ReferenceCountedObject{
+		public:
+			typedef ReferenceCountedObjectPtr<ReferenceCountedBuffer> Ptr;
+			ReferenceCountedBuffer (const String& nameToUse, AudioSampleBuffer buf)
+			: name (nameToUse), buffer (buf) {
+			}
 		
-		ReferenceCountedBuffer (const String& nameToUse, int numChannels, int numSamples)
-		: name (nameToUse), buffer (numChannels, numSamples) {
-		}
+			ReferenceCountedBuffer (const String& nameToUse, int numChannels, int numSamples)
+			: name (nameToUse), buffer (numChannels, numSamples) {
+			}
 		
-		~ReferenceCountedBuffer() {
-		}
+			~ReferenceCountedBuffer() {
+			}
 		
-		AudioSampleBuffer* getBuffer() {
-			return &buffer;
-		}
+			AudioSampleBuffer* getBuffer() {
+				return &buffer;
+			}
 		
-		bool bufferNotEmpty() {
-			return buffer.getNumSamples() > 0;
-		}
+			bool bufferNotEmpty() {
+				return buffer.getNumSamples() > 0;
+			}
 		
-	private:
-		String name;
-		AudioSampleBuffer buffer;
-		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ReferenceCountedBuffer)
+		private:
+			String name;
+			AudioSampleBuffer buffer;
+			JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ReferenceCountedBuffer)
 	};
 	
-	//==============================================================================
 	enum IRType {
 		IR_NONE,
 		IR_TARGET,
@@ -69,11 +67,9 @@ public:
 		bool 		doFadeout;
 	};
 	
-    //==============================================================================
-    AutoKalibraDemoAudioProcessor();
-    ~AutoKalibraDemoAudioProcessor();
+    IRBaboonAudioProcessor();
+    ~IRBaboonAudioProcessor();
 
-    //==============================================================================
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
@@ -119,11 +115,9 @@ public:
 	void swapTargetBase();
 	void loadTarget(File file);
 
-    //==============================================================================
     AudioProcessorEditor* createEditor() override;
     bool hasEditor() const override;
 
-    //==============================================================================
     const String getName() const override;
 
     bool acceptsMidi() const override;
@@ -131,19 +125,18 @@ public:
     bool isMidiEffect() const override;
     double getTailLengthSeconds() const override;
 
-    //==============================================================================
     int getNumPrograms() override;
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
     const String getProgramName (int index) override;
     void changeProgramName (int index, const String& newName) override;
 
-    //==============================================================================
     void getStateInformation (MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
+	
+	
 private:
-    //==============================================================================
 	int sampleRate = 48000;
 	int generalHostBlockSize = 0;
 	
@@ -238,5 +231,5 @@ private:
 
 
 	
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AutoKalibraDemoAudioProcessor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (IRBaboonAudioProcessor)
 };

--- a/IRBaboonCombined/Source/PluginProcessor.h
+++ b/IRBaboonCombined/Source/PluginProcessor.h
@@ -91,14 +91,8 @@ public:
 	AudioSampleBuffer getIRFilt();
 	
 	void setPlayFiltered(bool filtered);
-	
-	/* Print and thumbnail thread */
-	void run() override;
-	void saveIRTarg();
-	void saveIRBase();
-	void saveCustomExt(IRType type);
+
 	std::string getDateTimeString();
-	void printDebug();
 	std::string getPrintDirectoryDebug();
 	std::string getSavedIRExtension();
 	
@@ -223,7 +217,15 @@ private:
 	int savedIndex = 0;
 	
 	
+	/* Print and thumbnail thread */
+	void run() override;
+	void saveIRTarg();
+	void saveIRBase();
+	void saveCustomExt(IRType type);
+	void printDebug();
+	void printThumbnails();
 
+	
 	// ====== debug ==========
 	ParallelBufferPrinter debugPrinter;
 	

--- a/IRBaboonCombined/Source/tools.cpp
+++ b/IRBaboonCombined/Source/tools.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2020 Felix Postma. All rights reserved.
+//  Copyright © 2020 Felix Postma. 
 //
 
 #include <stdio.h>


### PR DESCRIPTION
Split printing of .wavs and .tsvs into conditional debug file printing, and unconditional thumbnail printing (always when the print thread is triggered). 

Fixes #6 